### PR TITLE
Automate building of packages in OBS

### DIFF
--- a/.github/buildzthin_deb_tar
+++ b/.github/buildzthin_deb_tar
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Copyright 2024 Contributors to the Open Mainframe Project.
+
+REPO=https://github.com/openmainframeproject/feilong
+REPOTOP=feilong
+ZTHIN=zthin-parts
+
+git clone $REPO
+cd $REPOTOP/$ZTHIN
+
+mkdir -p debian
+
+# Copy files with error handling
+echo "Attempting to copy zvmsdklogs to $REPOTOP:"
+cp ../../zthinlogs . || { echo "Failed to copy zvmsdklogs"; exit 1; }
+cp -r ../../zthindeb/* debian/ || { echo "Failed to copy files to debian directory"; exit 1; }
+
+# start the real debian build
+dpkg-buildpackage -S

--- a/.github/buildzthin_tar
+++ b/.github/buildzthin_tar
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Copyright 2024 Contributors to the Open Mainframe Project.
+
+REPO=https://github.com/openmainframeproject/feilong
+REPOTOP=feilong
+ZTHINTOP=zthin-parts
+
+# Clone the repository
+git clone $REPO
+# Change to the cloned directory
+cd $REPOTOP
+
+# Copy files to the build directory with error handling
+echo "Attempting to copy zthinlogs to $ZTHINTOP:"
+cp ../zthinlogs $ZTHINTOP/ || { echo "Failed to copy zthinlogs"; exit 1; }
+
+# Create the tarball
+tar czf zthin-build.tar.gz $ZTHINTOP

--- a/.github/buildzvmsdk_deb_tar
+++ b/.github/buildzvmsdk_deb_tar
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Copyright 2024 Contributors to the Open Mainframe Project.
+
+REPO=https://github.com/openmainframeproject/feilong
+REPOTOP=feilong
+ZTHIN=zthin-parts
+
+git clone $REPO
+cd $REPOTOP/$ZTHIN
+
+mkdir -p debian
+
+# Copy files with error handling
+echo "Attempting to copy zvmsdklogs to $REPOTOP:"
+cp ../../zthinlogs . || { echo "Failed to copy zvmsdklogs"; exit 1; }
+cp -r ../../zthindeb/* debian/ || { echo "Failed to copy files to debian directory"; exit 1; }
+
+# start the real debian build
+dpkg-buildpackage -S
+#!/bin/sh
+# Copyright 2017 IBM Corp.
+# Copyright 2024 Contributors to the Open Mainframe Project.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#------------------------------------------------------------------------------
+
+REPO=https://github.com/openmainframeproject/feilong
+REPOTOP=feilong
+
+# Clone the repository
+git clone $REPO
+cd $REPOTOP || { echo "Failed to change directory to $REPOTOP"; exit 1; }
+
+mkdir -p debian || { echo "Failed to create debian directory"; exit 1; }
+
+# Copy files with error handling
+echo "Attempting to copy zvmsdklogs to $REPOTOP:"
+cp ../zvmsdklogs . || { echo "Failed to copy zvmsdklogs"; exit 1; }
+cp ../vhost_deb.config . || { echo "Failed to copy vhost_deb"; exit 1; }
+cp -r ../sdkdeb/* debian/ || { echo "Failed to copy files to debian directory"; exit 1; }
+
+# Build the package
+dpkg-buildpackage -S

--- a/.github/buildzvmsdk_tar
+++ b/.github/buildzvmsdk_tar
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Copyright 2024 Contributors to the Open Mainframe Project.
+
+REPO=https://github.com/openmainframeproject/feilong
+REPOTOP=feilong
+SDK=zvmsdk
+
+# Clone the repository
+git clone $REPO
+# Change to the cloned directory
+cd $REPOTOP
+
+# Copy files to the build directory with error handling
+echo "Attempting to copy zvmsdklogs to $REPOTOP:"
+cp ../zvmsdklogs . || { echo "Failed to copy zvmsdklogs"; exit 1; }
+
+# Create the tarball
+cd ..
+tar czf zvmsdk.tar.gz --exclude "$REPOTOP/.git" --exclude "$REPOTOP/zthin-parts" $REPOTOP

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,121 @@
+# Copyright 2024 Contributors to the Open Mainframe Project.
+
+name: Package Feilong
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [obs-package]
+
+jobs:
+  zthin_tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out build-zvmsdk repository
+        uses: actions/checkout@v4
+
+      - name: Make buildzthin_tar executable
+        run: chmod +x ./.github/buildzthin_tar
+
+      - name: Run buildzthin_tar script
+        run: ./.github/buildzthin_tar master
+
+      - name: Upload zthin tarball artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zthin-tarball
+          path: feilong/zthin-build.tar.gz
+          compression-level: 0
+
+  zvmsdk_tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out build-zvmsdk repository
+        uses: actions/checkout@v4
+
+      - name: Make buildzvmsdk_tar executable
+        run: chmod +x ./.github/buildzvmsdk_tar
+
+      - name: Run buildzvmsdk_tar script
+        run: ./.github/buildzvmsdk_tar master
+
+      - name: Upload zvmsdk RPM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zvmsdk-tarball
+          path: zvmsdk.tar.gz
+          compression-level: 0 # no compression
+
+  zthin_deb_tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out build-zvmsdk repository
+        uses: actions/checkout@v4
+
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y debhelper dh-make dh-python python3-all
+      - name: Make buildzthin_deb_tar executable
+        run: chmod +x ./.github/buildzthin_deb_tar
+
+
+      - name: Run buildzthin_deb_tar script
+        run: ./.github/buildzthin_deb_tar master
+
+      - name: Upload zthin RPM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zthin-deb-tarball
+          path: |
+            feilong/zthin_3.1.2.tar.gz
+            feilong/zthin_3.1.2.dsc
+          compression-level: 0
+
+  zvmsdk_deb_tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out build-zvmsdk repository
+        uses: actions/checkout@v4
+
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y debhelper dh-make dh-python python3-all
+      - name: Make buildzvmsdk_deb_tar executable
+        run: chmod +x ./.github/buildzvmsdk_deb_tar
+
+      - name: Run buildzvmsdk_deb_tar script
+        run: ./.github/buildzvmsdk_deb_tar master
+
+      - name: Upload zvmsdk RPM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zvmsdk-deb-tarball
+          path: |
+            zvmsdk_1.4.0.dsc
+            zvmsdk_1.4.0.tar.gz
+          compression-level: 0
+
+  push_artifacts:
+    needs: [ zthin_tarball, zvmsdk_tarball, zthin_deb_tarball, zvmsdk_deb_tarball ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out build-zvmsdk repository
+        uses: actions/checkout@v4
+
+      - name: Download tarballs from artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: obs-artifacts
+          merge-multiple: true
+      - run: ls -R obs-artifacts
+
+      - name: Push  to the repository
+        run: |
+          cd obs-artifacts
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "Updated tarballs "
+          git push

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,0 +1,17 @@
+# Copyright 2024 Contributors to the Open Mainframe Project.
+
+workflow:
+  steps:
+    - trigger_services:
+        project: Virtualization:feilong
+        package: zthin_deb
+        package: zthin_rhel
+        package: zthin_sles
+        package: zvmsdk_deb
+        package: zvmsdk_rhel
+        package: zvmsdk_sles
+  filters:
+    branches:
+      only:
+        - master
+    event: push


### PR DESCRIPTION
This PR is part of the Feilong Packaging Process to automate building of packages (zthin and zvmsdk) for the 3 distros (Ubuntu, RHEL, SLES) on OBS.

In order for this automation to work, we must use a webhook in order for OBS to receive events from the github action to trigger the rebuild of the packages with the latest source files. 
In order to use the webhook, we require a Personal Access Token (PAT) which will be used by OBS to generate the url for the webhook.

The working of the action is as follows: 
- When build-zvmsdk receives the dispatched event from this (feilong) github action, it first runs a few script files to generate new tarballs from the latest version of the feilong master branch.
- After creating all the source files, it downloads them as artifacts and pushes them to the master branch of build-zvmsdk.
- Once build-zvmsdk has a push, it triggers the webhook with OBS which causes each package hosted on OBS to download the required tarballs and/or .dsc files followed by triggering a rebuild for each package.

This [PR](https://github.com/openmainframeproject/feilong/pull/839) handles the development on `feilong` side.

Please create a PAT on github for this repository.
The webhook will then be created with the `Push` event.